### PR TITLE
Update fclone.js

### DIFF
--- a/src/fclone.js
+++ b/src/fclone.js
@@ -36,8 +36,6 @@ function fclone(obj, refs) {
     copy.name = obj.name;
     copy.message = obj.message;
     copy.stack = obj.stack;
-    refs.length && refs.length--
-    return copy;
   }
 
   let keys = Object.keys(obj);

--- a/src/fclone.js
+++ b/src/fclone.js
@@ -4,9 +4,7 @@ function fclone(obj, refs) {
   if (!obj || "object" !== typeof obj) return obj;
 
   if (obj instanceof Date) {
-    let copy = new Date();
-    copy.setTime(obj.getTime());
-    return copy;
+    return new Date(obj);
   }
 
   if (Buffer !== undefined && Buffer.isBuffer(obj)) {


### PR DESCRIPTION
Don't return early from Error instance, object may have other properties, especially in frameworks that extend upon Error, for use with specific response codes, etc.

Also, `new Date(obj)` will clone the date, no need to create a date, then assign the value as separate commands.
